### PR TITLE
feat: add showOverlay prop to dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artstorefronts/ui",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,10 +31,12 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showOverlay?: boolean;
+  }
+>(({ className, children, showOverlay = true, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    {showOverlay && <DialogOverlay />}
     <DialogPrimitive.Content
       ref={ref}
       className={cn(

--- a/src/stories/dialog.stories.tsx
+++ b/src/stories/dialog.stories.tsx
@@ -31,7 +31,7 @@ const Template: StoryFn = (args) => (
     <DialogTrigger asChild>
       <Button variant="outline">Edit Profile</Button>
     </DialogTrigger>
-    <DialogContent className="sm:max-w-[425px]">
+    <DialogContent className="sm:max-w-[425px]" showOverlay={args.showOverlay}>
       <DialogHeader>
         <DialogTitle>Edit profile</DialogTitle>
         <DialogDescription>
@@ -60,3 +60,9 @@ const Template: StoryFn = (args) => (
 );
 
 export const Default = Template.bind({});
+
+export const WithoutOverlay = Template.bind({});
+WithoutOverlay.args = {
+  showOverlay: false,
+};
+


### PR DESCRIPTION
Enables a Dialog without an overlay behind it.

Changelog:

- Dialog component updated with showOver prop (defaults to true)
- "Without Overlay" Story added

<img width="1093" height="826" alt="Screenshot 2025-07-28 at 10 58 46 AM" src="https://github.com/user-attachments/assets/bc12ce1c-050f-403a-aaa0-2251ff4f3899" />
